### PR TITLE
parseInvite is not a function

### DIFF
--- a/index.js
+++ b/index.js
@@ -405,7 +405,7 @@ exports.init = function (sbot, config) {
   //TODO: check if invite is already held locally
   //      if so, just get it. when got, update local db.
   invites.openInvite = function (invite, cb) {
-    if(isString(invite)) invite = u.parseInvite(invite)
+    if(isString(invite)) invite = u.parse(invite)
     invites.getInvite(invite.invite, function (err, msg) {
       if(msg)
         next(msg)
@@ -437,7 +437,7 @@ exports.init = function (sbot, config) {
   }
 
   invites.acceptInvite = function (opts, cb) {
-    if(isString(opts)) opts = u.parseInvite(opts)
+    if(isString(opts)) opts = u.parse(opts)
     var invite = isObject(opts.invite) ? opts.invite : opts
     var invite_id = invite.invite
     var id = opts.id || sbot.id


### PR DESCRIPTION
```
/Users/cryptix/ssb/scuttle-shell/node_modules/ssb-server/node_modules/muxrpcli/index.js:68
      throw err
      ^
TypeError: u.parseInvite is not a function
    at Object.invites.openInvite (/Users/cryptix/ssb/scuttle-shell/node_modules/ssb-user-invites/index.js:408:37)
    at Object.hooked (/Users/cryptix/ssb/scuttle-shell/node_modules/ssb-server/node_modules/hoox/index.js:10:15)
    at Object.localCall (/Users/cryptix/ssb/scuttle-shell/node_modules/ssb-server/node_modules/muxrpc/local-api.js:31:29)
    at Object.<anonymous> (/Users/cryptix/ssb/scuttle-shell/node_modules/ssb-server/node_modules/muxrpc/local-api.js:37:22)
    at Object.request (/Users/cryptix/ssb/scuttle-shell/node_modules/ssb-server/node_modules/muxrpc/stream.js:48:17)
    at PacketStream._onrequest (/Users/cryptix/ssb/scuttle-shell/node_modules/ssb-server/node_modules/packet-stream/index.js:161:17)
    at PacketStream.write (/Users/cryptix/ssb/scuttle-shell/node_modules/ssb-server/node_modules/packet-stream/index.js:134:41)
    at /Users/cryptix/ssb/scuttle-shell/node_modules/ssb-server/node_modules/muxrpc/pull-weird.js:56:15
    at /Users/cryptix/ssb/scuttle-shell/node_modules/ssb-server/node_modules/pull-stream/sinks/drain.js:24:37
    at /Users/cryptix/ssb/scuttle-shell/node_modules/ssb-server/node_modules/pull-goodbye/node_modules/pull-stream/throughs/filter.js:17:11
```