### PR TITLE
fix some "variable not defined" bugs

### DIFF
--- a/index.js
+++ b/index.js
@@ -404,7 +404,7 @@ exports.init = function (sbot, config) {
         } else {
           err = err || _err
         }
-        if(--n == 0) cb(explain(err, 'while trying to connect to:'+remote))
+        if(--n == 0) cb(explain(err, 'while trying to connect to:'+addr))
       })
     })
   }
@@ -429,7 +429,7 @@ exports.init = function (sbot, config) {
         var invite_id = '%'+ssbKeys.hash(JSON.stringify(msg, null, 2))
         if(invite.invite !== invite_id)
           return cb(new Error(
-            'incorrect invite was returned! expected:'+invite.invite+', but got:'+inviteId
+            'incorrect invite was returned! expected:'+invite.invite+', but got:'+invite_id
           ))
         var opened
         try { opened = I.verifyInvitePrivate(msg, invite.seed, caps) }


### PR DESCRIPTION
got some breaking bugs while trying to use this module

ran
```
$ standard | grep 'not defined'
```
and took my best guess as to how these were meant to be defined