### PR TITLE
expose getNearbyPubs method, and fix some stuff

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+sudo: false
+node_js:
+  - 8
+  - 10

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ This can be parsed using `require('ssb-peer-invites/util').parse`
 
 ## api
 
-### peerInvites.create({id?, public?, reveal?, hops?}, cb(err, invite))
+### peerInvites.create({id?, public?, reveal?, hops?, pubs?, allowWithoutPubs?}, cb(err, invite))
 
 does everything needed to create an invite. generates a seed, finds pubs to act
 as introducers, and publishes an invite message.
@@ -116,6 +116,10 @@ or links to threads or channels, or peers to follow.
 
 on success, cb is called with an invite string, 
 this should be passed to the guest, who uses it with `openInvite` and `acceptInvite`
+
+If `allowWithoutPubs` is set, the invite will be created without finding any pubs.
+if `pubs` is provided this will be used the invite's pubs. `pubs` should be a array
+of multiserver addresses.
 
 ### peerInvites.openInvite(invite, cb(err, invite_msg, content)
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ If `allowWithoutPubs` is set, the invite will be created without finding any pub
 if `pubs` is provided this will be used the invite's pubs. `pubs` should be a array
 of multiserver addresses.
 
-### peerInvites.openInvite(invite, cb(err, invite_msg, content)
+### peerInvites.openInvite(invite, cb(err, data))
 
 "open" an invite. retrives the invite message created by the host (using `peerInvites.create`)
 and decrypt any encrypted values. since the invite may contain a welcome message, etc,
@@ -130,6 +130,18 @@ firstly opening the invite, then accepting (on peer confirmation)
 
 calling openInvite will not publish a message, but may make a network connection
 (if you do not already possess the `invite_msg` which you won't the first time)
+
+the if the invite validated, the data argument is provided.
+```
+data = {
+  key: invite_id, //id of the invite message
+  value: invite_msg, //the raw invite message itself
+  opened: {
+    private: ..., //private message from host (may be null)
+    reveal: ... //message to be revealed from host (may be null)
+  }
+}
+```
 
 ### peerInvites.acceptInvite(invite, cb)
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,34 @@ calling openInvite will not publish a message, but may make a network connection
 accept the invite. this publishes a `peer-invite/accept` message locally,
 and then contacts a pub and asks them publish a `peer-invite/confirm` message.
 
+### peerInvites.getNearbyPubs(opts, cb)
+
+Get a list of nearby pubs, that may act as introducer to onboard the guest.
+to support `peer-invites` pubs must be running `ssb-device-address`
+and `ssb-peer-invites`, and be enough within your hop distance that they
+are happy to replicate someone you've invited. `create` uses this method
+internally, but it is provided for debugging purposes.
+
+supported options:
+* `hops` set the max hops of pubs to try. (defaults to 3
+* `min` connect to pubs until you've found at least this many who will replicate.
+
+The format of the result is:
+
+``` js
+[{
+  id: <pub_id>,
+  address: <multiserver_address>,
+  availability: <0-1>,
+  hops: N, //how far away they are
+  error: <null|message>, //if the connection failed
+  willReplicate: boolean, //true if they can handle this invite!
+},
+...
+]
+```
+results are sorted by wether they will replicate, and then by availability.
+
 ## example
 
 Alice wishes to invite Bob to her corner of the ssb

--- a/cap.js
+++ b/cap.js
@@ -1,3 +1,4 @@
 var u = require('./util.js')
 
-module.exports = u.hash('peer-invites')
+//todo: get this from ssb-caps@1.1 instead
+module.exports = u.hash('peer-invites').toString('base64')

--- a/cap.js
+++ b/cap.js
@@ -1,11 +1,3 @@
-var chloride = require('chloride')
+var u = require('./util.js')
 
-function hash(s) {
-  return chloride.crypto_hash_sha256(
-    'string' == typeof s ? new Buffer(s, 'utf8') : s
-  )
-}
-
-module.exports =  hash("peer-invites:DEVELOPMENT") //XXX DON'T publish without fixing this!
-
-// TODO
+module.exports = u.hash('peer-invites')

--- a/index.js
+++ b/index.js
@@ -450,7 +450,11 @@ exports.init = function (sbot, config) {
         // this is a wee bit naughty, because if you rebuild the index it might not have this invite
         // (until you replicate it, but when you do the value won't change)
         state.set(reduce(state.value, {key: invite_id, value:msg}, invites.since.value))
-        cb(null, msg, opened)
+        cb(null, {
+          key: invite_id,
+          value: msg,
+          opened: opened
+        })
       }
     })
   }
@@ -466,7 +470,10 @@ exports.init = function (sbot, config) {
     getAccept(invite_id, function (err, accept) {
       if(accept) next(accept)
       else {
-        invites.openInvite(invite, function (err, invite_msg, opened) {
+        invites.openInvite(invite, function (err, data) {
+          if(err) return cb(err)
+          var invite_msg = data.value
+          var opened = data.opened
           sbot.identities.publishAs({
             id: id,
             content: I.createAccept(invite_msg, invite.seed, id, caps)

--- a/index.js
+++ b/index.js
@@ -404,7 +404,7 @@ exports.init = function (sbot, config) {
         } else {
           err = err || _err
         }
-        if(--n == 0) cb(explain(err, 'while trying to connect to:'+remote))
+        if(--n == 0) cb(explain(err, 'while trying to connect to:'+addr))
       })
     })
   }
@@ -429,7 +429,7 @@ exports.init = function (sbot, config) {
         var invite_id = '%'+ssbKeys.hash(JSON.stringify(msg, null, 2))
         if(invite.invite !== invite_id)
           return cb(new Error(
-            'incorrect invite was returned! expected:'+invite.invite+', but got:'+inviteId
+            'incorrect invite was returned! expected:'+invite.invite+', but got:'+invite_id
           ))
         var opened
         try { opened = I.verifyInvitePrivate(msg, invite.seed, caps) }

--- a/test/accept.js
+++ b/test/accept.js
@@ -34,7 +34,7 @@ var bob = createSbot({
   caps: caps
 })
 
-tape('create an invite', function (t) {
+tape('create an invite (accept)', function (t) {
 
   var seed = crypto.randomBytes(32)
 

--- a/test/accept2.js
+++ b/test/accept2.js
@@ -36,7 +36,6 @@ var bob = createSbot({
   keys:ssbKeys.generate(),
   caps: caps
 })
-console.log(alice, bob)
 
 function toId(msg) {
   return '%'+ssbKeys.hash(JSON.stringify(msg, null, 2))

--- a/test/accept2.js
+++ b/test/accept2.js
@@ -52,11 +52,13 @@ tape('create an invite (accept2)', function (t) {
     //use device address, just for tests
     invite.pubs.push(alice.getAddress('device'))
 
-    bob.peerInvites.openInvite(invite, function (err, invite_msg, data) {
+    bob.peerInvites.openInvite(invite, function (err, data) {
       if(err) throw err
+      var invite_msg = data.value
+      var opened = data.opened
       t.ok(invite)
       t.equal(toId(invite_msg), invite_id)
-      t.deepEqual(data, {reveal: undefined, private: undefined})
+      t.deepEqual(opened, {reveal: undefined, private: undefined})
       //check this invite is valid. would throw if it wasn't.
       bob.peerInvites.acceptInvite(invite, function (err, confirm) {
         if(err) throw err
@@ -75,4 +77,3 @@ tape('create an invite (accept2)', function (t) {
     })
   })
 })
-

--- a/test/accept2.js
+++ b/test/accept2.js
@@ -1,11 +1,9 @@
 //WARNING: this test currently only passes
 //if the computer has a network.
-var crypto = require('crypto')
 var u = require('../util')
 
 var ssbKeys = require('ssb-keys')
 var tape = require('tape')
-var pull = require('pull-stream')
 
 var createSbot = require('ssb-server')
   .use(require('ssb-links'))
@@ -38,12 +36,13 @@ var bob = createSbot({
   keys:ssbKeys.generate(),
   caps: caps
 })
+console.log(alice, bob)
 
 function toId(msg) {
   return '%'+ssbKeys.hash(JSON.stringify(msg, null, 2))
 }
 
-tape('create an invite', function (t) {
+tape('create an invite (accept2)', function (t) {
 
   alice.peerInvites.create({allowWithoutPubs: true}, function (err, _invite) {
     if(err) throw err

--- a/test/accept3.js
+++ b/test/accept3.js
@@ -1,12 +1,9 @@
 //WARNING: this test currently only passes
 //if the computer has a network.
-var crypto = require('crypto')
 var u = require('../util')
 
 var ssbKeys = require('ssb-keys')
 var tape = require('tape')
-var pull = require('pull-stream')
-var ref = require('ssb-ref')
 
 var createSbot = require('ssb-server')
   .use(require('ssb-links'))
@@ -44,7 +41,7 @@ var bob = createSbot({
   caps: caps
 })
 
-tape('create an invite', function (t) {
+tape('create an invite (accept3)', function (t) {
 
   //in this test, we use a separate identity to create the invite,
   //to test multiple identity support, and also simulate confirmation by pub.

--- a/test/accept3.js
+++ b/test/accept3.js
@@ -55,12 +55,14 @@ tape('create an invite (accept3)', function (t) {
       //use device address, just for tests
       invite.pubs.push(alice.getAddress('device'))
 
-      bob.peerInvites.openInvite(invite, function (err, invite_msg, data) {
+      bob.peerInvites.openInvite(invite, function (err, data) {
         if(err) throw err
+        var invite_msg = data.value
+        var opened = data.opened
         t.ok(invite)
         t.equal(invite_msg.author, carol_id)
         t.equal(toId(invite_msg), invite_id)
-        t.deepEqual(data, {reveal: undefined, private: undefined})
+        t.deepEqual(opened, {reveal: undefined, private: undefined})
         //check this invite is valid. would throw if it wasn't.
         bob.peerInvites.acceptInvite(invite, function (err, confirm) {
           if(err) throw err
@@ -82,4 +84,3 @@ tape('create an invite (accept3)', function (t) {
     })
   })
 })
-

--- a/test/accept4.js
+++ b/test/accept4.js
@@ -51,11 +51,13 @@ tape('create an invite (accept4)', function (t) {
     //use device address, just for tests
     invite.pubs.push(alice.getAddress('device'))
 
-    bob.peerInvites.openInvite(u.stringify(invite), function (err, invite_msg, data) {
+    bob.peerInvites.openInvite(u.stringify(invite), function (err, data) {
       if(err) throw err
+      var invite_msg = data.value
+      var opened = data.opened
       t.ok(invite)
       t.equal(toId(invite_msg), invite_id)
-      t.deepEqual(data, {reveal: undefined, private: undefined})
+      t.deepEqual(opened, {reveal: undefined, private: undefined})
 
       //bob publishes accept_content manually. simulates that he crashed
       //before causing confirm.
@@ -83,7 +85,3 @@ tape('create an invite (accept4)', function (t) {
     })
   })
 })
-
-
-
-

--- a/test/accept4.js
+++ b/test/accept4.js
@@ -1,10 +1,8 @@
-var crypto = require('crypto')
 var I = require('../valid')
 var u = require('../util')
 
 var ssbKeys = require('ssb-keys')
 var tape = require('tape')
-var pull = require('pull-stream')
 
 var createSbot = require('ssb-server')
   .use(require('ssb-links'))
@@ -42,7 +40,7 @@ var bob = createSbot({
   caps: caps
 })
 
-tape('create an invite', function (t) {
+tape('create an invite (accept4)', function (t) {
 
   alice.peerInvites.create({allowWithoutPubs: true}, function (err, _invite) {
     if(err) throw err

--- a/test/accept5.js
+++ b/test/accept5.js
@@ -50,12 +50,14 @@ tape('create an invite (accept5)', function (t) {
 
     //use device address, just for tests
     invite.pubs.push(alice.getAddress('device'))
+    t.ok(invite)
 
-    bob.peerInvites.openInvite(u.stringify(invite), function (err, invite_msg, data) {
+    bob.peerInvites.openInvite(u.stringify(invite), function (err, data) {
       if(err) throw err
-      t.ok(invite)
+      var invite_msg = data.value
+      var opened = data.opened
       t.equal(toId(invite_msg), invite_id)
-      t.deepEqual(data, {reveal: undefined, private: undefined})
+      t.deepEqual(opened, {reveal: undefined, private: undefined})
 
       //bob publishes accept_content manually. simulates that he crashed
       //before causing confirm.
@@ -92,4 +94,3 @@ tape('create an invite (accept5)', function (t) {
     })
   })
 })
-

--- a/test/accept5.js
+++ b/test/accept5.js
@@ -1,10 +1,8 @@
-var crypto = require('crypto')
 var I = require('../valid')
 var u = require('../util')
 
 var ssbKeys = require('ssb-keys')
 var tape = require('tape')
-var pull = require('pull-stream')
 
 var createSbot = require('ssb-server')
   .use(require('ssb-links'))
@@ -42,7 +40,7 @@ var bob = createSbot({
   caps: caps
 })
 
-tape('create an invite', function (t) {
+tape('create an invite (accept5)', function (t) {
 
   alice.peerInvites.create({allowWithoutPubs: true}, function (err, _invite) {
     if(err) throw err

--- a/test/invite-with-pubs.js
+++ b/test/invite-with-pubs.js
@@ -113,9 +113,9 @@ tape('accept invite', function (t) {
     if(err) throw err
     t.deepEqual(invite.pubs, [carol.getAddress('device')])
     
-    bob.peerInvites.openInvite(invite, function (err, _invite_msg) {
+    bob.peerInvites.openInvite(invite, function (err, data) {
       if(err) throw explain(err, 'error while opening invite')
-      t.deepEqual(_invite_msg, invite_msg)
+      t.deepEqual(data.value, invite_msg)
       bob.peerInvites.acceptInvite(invite, function (err) {
         if(err) throw err
         t.end()
@@ -136,6 +136,3 @@ tape('cleanup', function (t) {
     t.end()
   }, 1000)
 })
-
-
-

--- a/test/nearby.json
+++ b/test/nearby.json
@@ -1,0 +1,66 @@
+[
+  {
+    "id": "@lbocEWqF2Fg6WMYLgmfYvqJlMfL7hiqVAV6ANjHWNw8=.ed25519",
+    "address": "onion:4fqstkswahy3n7mupr2gvvp2qcsp6juwzn3mnqvhkaixxepvxrrtfbid.onion:8008~shs:lbocEWqF2Fg6WMYLgmfYvqJlMfL7hiqVAV6ANjHWNw8=",
+    "availability": 1,
+    "hops": 2,
+    "error": "connect ECONNREFUSED 127.0.0.1:9150",
+    "willReplicate": false
+  },
+  {
+    "id": "@DTNmX+4SjsgZ7xyDh5xxmNtFqa6pWi5Qtw7cE8aR9TQ=.ed25519",
+    "address": "net:128.199.132.182:8008~shs:DTNmX+4SjsgZ7xyDh5xxmNtFqa6pWi5Qtw7cE8aR9TQ=;ws://128.199.132.182:9009~shs:DTNmX+4SjsgZ7xyDh5xxmNtFqa6pWi5Qtw7cE8aR9TQ=",
+    "availability": 1,
+    "hops": 1,
+    "error": null,
+    "willReplicate": true
+  },
+  {
+    "id": "@WndnBREUvtFVF14XYEq01icpt91753bA+nVycEJIAX4=.ed25519",
+    "address": "net:pub.t4l3.net:8008~shs:WndnBREUvtFVF14XYEq01icpt91753bA+nVycEJIAX4=",
+    "availability": 1,
+    "hops": 2,
+    "error": "connect ECONNREFUSED 173.249.55.204:8008",
+    "willReplicate": false
+  },
+  {
+    "id": "@5XaVcAJ5DklwuuIkjGz4lwm2rOnMHHovhNg7BFFnyJ8=.ed25519",
+    "address": "net:ssb.celehner.com:8008~shs:5XaVcAJ5DklwuuIkjGz4lwm2rOnMHHovhNg7BFFnyJ8=",
+    "availability": 1,
+    "hops": 2,
+    "error": null,
+    "willReplicate": true
+  },
+  {
+    "id": "@N7jw0alZkW7Id+vLUjcf0Zs/xwff8z4BT6bCpq99EKw=.ed25519",
+    "address": "net:fc2d:4733:219f:c0dc:8809:1bb9:e1ab:2f94~shs:N7jw0alZkW7Id+vLUjcf0Zs/xwff8z4BT6bCpq99EKw=",
+    "availability": 0.5,
+    "hops": 2,
+    "error": "could not connect to:net:fc2d:4733:219f:c0dc:8809:1bb9:e1ab:2f94~shs:N7jw0alZkW7Id+vLUjcf0Zs/xwff8z4BT6bCpq99EKw=, only know:net~shs;onion~shs",
+    "willReplicate": false
+  },
+  {
+    "id": "@uOReuhnb9+mPi5RnTbKMKRr3r87cK+aOg8lFXV/SBPU=.ed25519",
+    "address": "net:fc4c:743b:691e:c2aa:276e:d214:d557:3055~shs:uOReuhnb9+mPi5RnTbKMKRr3r87cK+aOg8lFXV/SBPU=",
+    "availability": 0.7,
+    "hops": 2,
+    "error": "getaddrinfo ENOTFOUND fc4c:743b:691e:c2aa:276e:d214:d557 fc4c:743b:691e:c2aa:276e:d214:d557:3055",
+    "willReplicate": false
+  },
+  {
+    "id": "@uMiN0TRVMGVNTQUb6KCbiOi/8UQYcyojiA83rCghxGo=.ed25519",
+    "address": "net:ssb.learningsocieties.org:8008~shs:uMiN0TRVMGVNTQUb6KCbiOi/8UQYcyojiA83rCghxGo=",
+    "availability": 0.9,
+    "hops": 2,
+    "error": "connect ECONNREFUSED 188.166.52.34:8008",
+    "willReplicate": false
+  },
+  {
+    "id": "@GPz52umhSy9c4Qu7jBLd9mDOysvxyy3TcjzUzsaZHVA=.ed25519",
+    "address": "net:pub.scuttlebuttchess.co.uk:8008~shs:GPz52umhSy9c4Qu7jBLd9mDOysvxyy3TcjzUzsaZHVA=",
+    "availability": 0.3,
+    "hops": 2,
+    "error": "method:peerInvites,willReplicate is not in list of allowed methods",
+    "willReplicate": false
+  }
+]

--- a/test/will-replicate.js
+++ b/test/will-replicate.js
@@ -1,5 +1,6 @@
 var ssbKeys = require('ssb-keys')
 var tape = require('tape')
+var u = require('../util')
 
 var createSbot = require('ssb-server')
   .use(require('ssb-links'))
@@ -63,6 +64,15 @@ tape("bob won't replicate alice's guests", function (t) {
       t.end()
     })
   })
+})
+
+var nearby = require('./nearby.json')
+tape('sort', function (t) {
+  var sorted = u.sort(nearby)
+  t.ok(sorted[0].willReplicate)
+  t.ok(sorted[1].willReplicate)
+  console.log(sorted)
+  t.end()
 })
 
 tape('clean up', function (t) {

--- a/util.js
+++ b/util.js
@@ -1,13 +1,13 @@
 var chloride = require('chloride')
 
-function box (data, key) {
+exports.box = function box (data, key) {
   if(!data) return
-  var b = new Buffer(JSON.stringify(data))
+  var b = Buffer.from(JSON.stringify(data))
   return chloride.crypto_secretbox_easy(b, key.slice(0, 24), key).toString('base64')
 }
 
-function unbox (ctxt, key) {
-  var b = new Buffer(ctxt, 'base64')
+exports.unbox = function unbox (ctxt, key) {
+  var b = Buffer.from(ctxt, 'base64')
   var ptxt = chloride.crypto_secretbox_open_easy(b, key.slice(0, 24), key)
   if(!ptxt) return
   try {
@@ -17,17 +17,13 @@ function unbox (ctxt, key) {
   }
 }
 
-
-function hash(s) {
+exports.hash = function hash (s) {
   return chloride.crypto_hash_sha256(
-    'string' == typeof s ? new Buffer(s, 'utf8') : s
+    'string' === typeof s ? Buffer.from(s, 'utf8') : s
   )
 }
 
-exports.hash = hash
-exports.box = box
-exports.unbox = unbox
-exports.parse = function (str) {
+exports.parse = function parse (str) {
   if(!/^inv\:/.test(str)) throw new Error('invites must start with "inv:", got '+JSON.stringify(str))
   var ary = str.substring(4).split(',')
   return {
@@ -37,7 +33,7 @@ exports.parse = function (str) {
     pubs: ary.slice(3)
   }
 }
-exports.stringify = function (invite) {
+exports.stringify = function stringify (invite) {
   return 'inv:'+[
       invite.seed,
       invite.invite,
@@ -47,9 +43,9 @@ exports.stringify = function (invite) {
     .join(',')
 }
 
-exports.sort = function (found) {
+exports.sort = function sort (found) {
   return found.sort(function (a, b) {
-    console.log([a.willReplicate, b.willReplicate], (!!a.willReplicate) - (!!b.willReplicate), b.availability - a.availability);
+    // console.log([a.willReplicate, b.willReplicate], (!!a.willReplicate) - (!!b.willReplicate), b.availability - a.availability);
     return (!!b.willReplicate) - (!!a.willReplicate) || (b.availability - a.availability)
   })
 }

--- a/util.js
+++ b/util.js
@@ -45,7 +45,6 @@ exports.stringify = function stringify (invite) {
 
 exports.sort = function sort (found) {
   return found.sort(function (a, b) {
-    // console.log([a.willReplicate, b.willReplicate], (!!a.willReplicate) - (!!b.willReplicate), b.availability - a.availability);
     return (!!b.willReplicate) - (!!a.willReplicate) || (b.availability - a.availability)
   })
 }

--- a/util.js
+++ b/util.js
@@ -47,3 +47,9 @@ exports.stringify = function (invite) {
     .join(',')
 }
 
+exports.sort = function (found) {
+  return found.sort(function (a, b) {
+    console.log([a.willReplicate, b.willReplicate], (!!a.willReplicate) - (!!b.willReplicate), b.availability - a.availability);
+    return (!!b.willReplicate) - (!!a.willReplicate) || (b.availability - a.availability)
+  })
+}


### PR DESCRIPTION
@mixmix I noticed that the invite message you posted in `%1vXsHzVorHMF34cvKQu26y243J/F5rcSmqYOzMQkCq8=.sha256` had too many pubs,
and also some didn't actually support peer-invites.
the main problem was the pubs returned did not get sorted correctly, and also pubs that can't help should be filtered out.